### PR TITLE
Add EV calculation to data model

### DIFF
--- a/functions/src/utils/repository.ts
+++ b/functions/src/utils/repository.ts
@@ -159,10 +159,17 @@ export async function generateDataModelInventoryPerformance(
       getColumn(EColumnType.INVENTORY_VALUE).index!
     );
 
+    const grossMargin = getRowValue(
+      row,
+      getColumn(EColumnType.GROSS_MARGIN).index!
+    );
+
     const icrPercentage = Number(icrRow[category]);
+    const icc = icrPercentage * Number(inventoryValue);
 
     row[ESystemColumnType.ICR_PERCENTAGE] = icrPercentage;
-    row[ESystemColumnType.ICC] = icrPercentage * Number(inventoryValue);
+    row[ESystemColumnType.ICC] = icc;
+    row[ESystemColumnType.EV] = Number(grossMargin) - icc;
   }
 
   await uploadJsonFile(uid, fileUid, dataModel);

--- a/shared/enums/ESystemColumnType.ts
+++ b/shared/enums/ESystemColumnType.ts
@@ -3,6 +3,7 @@ import { EInventoryPerformaceMetricType } from "./EInventoryPerformaceMetricType
 export const ESystemColumnType = {
   ICR_PERCENTAGE: EInventoryPerformaceMetricType.ICR_PERCENTAGE,
   ICC: "system_icc",
+  EV: "system_ev",
 } as const;
 
 export type ESystemColumnType =


### PR DESCRIPTION
This pull request adds the calculation for EV (Enterprise Value) to the data model. The calculation is based on the gross margin and the ICC (Inventory Carrying Cost) percentage. The EV value is then added as a new column in the data model.